### PR TITLE
Use `rst2man` instead of `rst2man.py`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ SYSTEM       ?= $(system)
 #-------------------------------------------------------------------------------
 
 DIRNAME     := $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
-RST2MAN     := rst2man.py
+RST2MAN     := rst2man
 PROG        := butt
 DATAPATHVAR := BUTT_DATAPATH
 README      := README

--- a/configure
+++ b/configure
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-for cmd in rst2man.py make; do
+for cmd in rst2man make; do
   type $cmd > /dev/null 2>&1 && continue
   echo "Command $cmd not found." >&2
   exit 1


### PR DESCRIPTION
Most systems won't have `rst2man.py` even with docutils installed.

This is apparently breaking builds for omgf.